### PR TITLE
Remove space above the language bar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -44,8 +44,8 @@ h1, h2, h3 {
 }
 
 .header-link {
+  margin-top: 0;
   padding: 0px 5px 0px 5px;
-
 }
 
 .header-link-current {


### PR DESCRIPTION
The language link has a top margin that's adding space above the language bar. This removes it, though it doesn't do anything about the bottom margin. I'm not sure the best choice for the language link tag is a header, but it depends on your needs of course.