### PR TITLE
Addresses #5, Duplicate header styles from WordPress staging site

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,23 +2,26 @@
   /* == Color codes == */
   --darkest: black;
   --lightest: white;
-  --lightest-blue: #F5F9FE;
-  --light-blue-1: #6C9FE1;
+  /*--lightest-blue: #F5F9FE;*/
+  --lightest-blue: #e9f0f7;
+  --light-blue-1: #c3d8f5;
+  --light-blue-2: #6C9FE1;
   --blue: #1A73E8;
   --blue-dark-1: #005dd6;
   
   /* == Purposes == */
+  --header-link-color: var(--darkest);
+
+  /* wide */
+  --header-wide-text-hover: var(--light-blue-2);
+  --header-wide-text-current: var(--blue);
+
+  /* narrow */
+  --hamburger: var(--blue);
   --header-1024-item-border: var(--darkest);
   --header-1024-item-background: var(--blue);
-  /*--header-1024-item-current-background: var(--blue);*/
-  --header-1024-item-current-background: var(--blue-dark-1);
-
-  --header-link: var(--darkest);
-
-  --header-wide-text-hover: var(--light-blue-1);
-  --header-wide-text-current: var(--blue);
-  --header-1024-item-hover: var(--light-blue-1);
-  --header-1024-text: var(--darkest);
+  --header-1024-text: var(--light-blue-1);
+  --header-1024-text-hover: var(--lightest);
   --header-1024-text-current: var(--darkest);
 }
 
@@ -260,7 +263,7 @@ h1, h2, h3 {
   font-family: 'Quicksand', sans-serif;
   font-size: 1.05rem;
   font-weight: 700;
-  color: var(--header-link);
+  color: var(--header-link-color);
 }
 
 #header_nav .header-link,
@@ -278,7 +281,12 @@ h1, h2, h3 {
 .hamburger {
   width: 40px;
   height: 40px;
-  font-size: 1rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: var(--hamburger);
+  border: 1px solid var(--hamburger);
+  border-radius: 3px;
 }
 
 /* - wide - */
@@ -308,8 +316,12 @@ h1, h2, h3 {
   background-color: var(--header-1024-item-background);
 }
 
-#header_nav_container_1024 #header_nav li:hover {
-  background-color: var(--header-1024-item-hover);
+#header_nav_container_1024 #header_nav li span {
+  color: var(--header-1024-text);
+}
+
+#header_nav_container_1024 #header_nav li:hover span {
+  color: var(--header-1024-text-hover);
 }
 
 #header_nav_container_1024 #header_nav li {
@@ -321,13 +333,8 @@ h1, h2, h3 {
 }
 
 /* Styles for current header item are different that items and don't change with hover */
-#header_nav_container_1024 #header_nav .header-item-current,
-#header_nav_container_1024 #header_nav .header-item-current:hover {
-  /*$*/
-  background-color: var(--header-1024-item-current-background);
-}
 #header_nav_container_1024 #header_nav .header-item-current span,
-#header_nav_container_1024 #header_nav .header-item-current span:hover {
+#header_nav_container_1024 #header_nav .header-item-current:hover span {
   color: var(--header-1024-text-current);
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -1,7 +1,25 @@
 :root {
-  --header-item-hover: #6C9FE1;
+  /* == Color codes == */
+  --darkest: black;
+  --lightest: white;
+  --lightest-blue: #F5F9FE;
+  --light-blue-1: #6C9FE1;
   --blue: #1A73E8;
-  --lightblue: #F5F9FE;
+  --blue-dark-1: #005dd6;
+  
+  /* == Purposes == */
+  --header-1024-item-border: var(--darkest);
+  --header-1024-item-background: var(--blue);
+  /*--header-1024-item-current-background: var(--blue);*/
+  --header-1024-item-current-background: var(--blue-dark-1);
+
+  --header-link: var(--darkest);
+
+  --header-wide-text-hover: var(--light-blue-1);
+  --header-wide-text-current: var(--blue);
+  --header-1024-item-hover: var(--light-blue-1);
+  --header-1024-text: var(--darkest);
+  --header-1024-text-current: var(--darkest);
 }
 
 #root {
@@ -15,6 +33,12 @@ div {
 
 section {
   padding: 10px 30px 0 30px;
+}
+
+@media (max-width: 380px) {
+  section {
+    padding: 8px 15px 0 15px;
+  }
 }
 
 h1, h2, h3 {
@@ -33,9 +57,17 @@ h1, h2, h3 {
   text-align: right;
 }
 
+/* If the separator needs a background color, it will need a container */
 .separator {
+  /*margin: 0 auto;*/
+  margin: 10px 30px 0 30px;
   border-bottom: 1px solid black;
-  margin: 0 auto;
+}
+
+@media (max-width: 380px) {
+  .separator {
+    margin: 8px 15px 0 15px;
+  }
 }
 
 #language-container {
@@ -80,20 +112,21 @@ h1, h2, h3 {
   color: white;
 }
 
-/* App */
+/* ====== App ====== */
 .App {
   text-align: center;
   font-family: "Roboto", sans-serif;
   margin: 0 auto;
 }
-/*
-#header_section {
-  padding-top: 10px;
-}*/
 
 #header {
+  display: flex;
   justify-content: space-between;
   align-items: center;
+}
+
+#header_section {
+  position: relative;
 }
 
 .header-part {
@@ -105,53 +138,210 @@ h1, h2, h3 {
 }
 
 .header-part:last-child {
-  padding: 0;
-}
-
-nav .header-link {
-  padding: 0 20px;
-}
-
-nav .header-link:first-child {
-  padding-left: 0;
-}
-
-nav .header-link:last-child {
   padding-right: 0;
 }
 
-nav .header-link,
-nav .header-link:active,
-nav .header-link:link,
-nav .header-link:visited,
-nav .header-link:hover {
+/* == Header logo == */
+
+#header .logo-container {
+  width: 220px;
+  text-align: left;
+}
+
+@media (max-width: 380px) {
+  #header .logo-container {
+    width: 55%;
+  }
+}
+
+#header .logo-container img {
+  width: 100%;
+}
+
+/* == Header nav links containers == */
+
+#header_nav {
+  display: flex;
+  flex: 1;
+}
+
+/* Show/hide hamburger stuff */
+#header_nav_container_1024 {
+  display: none;
+}
+
+@media (max-width: 1024px) {
+  #header_nav_container_wide {
+    display: none;
+  }
+  #header_nav_container_1024 {
+    display: block;
+  }
+}
+
+/* == Actual nav list containers == */
+
+/* - wide - */
+#header_nav_container_wide #header_nav {
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+/* - narrow - */
+#header_nav_container_1024 #header_nav {
+  flex-direction: column;
+  justify-content: space-between;
+  position: absolute;
+  width: 100%;
+  left: 0;
+  top: 100%;
+}
+
+/* Expand and collapse hamburger's menu*/
+#header_nav_container_1024 #header_nav {
+  max-height: 0;
+  overflow: hidden;
+  transition: 0.1s linear;
+}
+
+/* WARNING: If the menu gets too much longer, this height must be increased */
+#header_nav_container_1024 #header_nav.expanded {
+  max-height: 300px;
+}
+
+/* == Header nav link lists == */
+
+#header_nav ul {
+  display: flex;
+  /* Neutralize default ul styles */
+  list-style-type: none;
+  margin-block-start: 0;
+  margin-block-end: 0;
+  margin-inline-start: 0;
+  margin-inline-end: 0;
+  padding-inline-start: 0;
+}
+
+#header_nav_container_wide #header_nav ul {
+  flex-direction: row;
+}
+
+#header_nav ul li {
+  /* Neutralize default li styles */
+  display: inline;
+  list-style-type: none;
+}
+
+/* - wide - */
+
+#header_nav_container_wide #header_nav li {
+  padding: 0 20px;
+}
+
+#header_nav_container_wide #header_nav li:first-child {
+  padding-left: 0;
+}
+
+#header_nav_container_wide #header_nav li:last-child {
+  padding-right: 0;
+}
+
+/* - narrow - */
+
+#header_nav_container_1024 #header_nav ul {
+  flex-direction: column;
+}
+
+/* == Header nav links == */
+
+#header_nav .header-link {
+  /* Override link styles */
+  display: block;
+  font-family: 'Quicksand', sans-serif;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--header-link);
+}
+
+#header_nav .header-link,
+#header_nav .header-link:active,
+#header_nav .header-link:link,
+#header_nav .header-link:visited,
+#header_nav .header-link:hover {
   text-decoration: none;
 }
 
-.header-link-text {
+#header_nav .header-link span {
+  margin: 0;
+}
+
+.hamburger {
+  width: 40px;
+  height: 40px;
+  font-size: 1rem;
+}
+
+/* - wide - */
+
+#header_nav_container_wide #header_nav .header-link-text:hover {
+  color: var(--header-wide-text-hover);
+}
+
+/* Styles for current header item are different that items and don't change with hover */
+#header_nav_container_wide #header_nav .header-item-current span,
+#header_nav_container_wide #header_nav .header-item-current span:hover {
+  color: var(--blue);
+}
+
+#header_nav_container_wide .header-link-text {
   margin: 0;
   padding: 0px 5px 0px 5px;
 }
 
-.header-link-text:hover {
-  color: var(--header-item-hover);
+/* - narrow - */
+
+#header_nav_container_1024 #header_nav .header-link {
+  padding: 1em;
 }
 
-.header-link-text:hover {
-  text-decoration: none;
+#header_nav_container_1024 #header_nav li {
+  background-color: var(--header-1024-item-background);
 }
 
-nav .header-link-text-current,
-nav .header-link-text-current:hover {
-  color: var(--blue);
+#header_nav_container_1024 #header_nav li:hover {
+  background-color: var(--header-1024-item-hover);
 }
+
+#header_nav_container_1024 #header_nav li {
+  border-bottom: 1px solid var(--header-1024-item-border);
+}
+
+#header_nav_container_1024 #header_nav li:first-child {
+  border-top: 1px solid var(--header-1024-item-border);
+}
+
+/* Styles for current header item are different that items and don't change with hover */
+#header_nav_container_1024 #header_nav .header-item-current,
+#header_nav_container_1024 #header_nav .header-item-current:hover {
+  /*$*/
+  background-color: var(--header-1024-item-current-background);
+}
+#header_nav_container_1024 #header_nav .header-item-current span,
+#header_nav_container_1024 #header_nav .header-item-current span:hover {
+  color: var(--header-1024-text-current);
+}
+
+#footer .logo {
+
+}
+
+/* ======== */
 
 .row {
   display: flex;
   flex: 1;
   margin: 0 auto;
   max-width: 700px;
-
 }
 
 .column {
@@ -212,7 +402,7 @@ nav .header-link-text-current:hover {
 
 
 .section {
-  background-color: var(--lightblue);
+  background-color: var(--lightest-blue);
   padding: 20px 0;
   width: 100vw;
   margin: 20px 0 20px calc(50% - 50vw);
@@ -221,7 +411,7 @@ nav .header-link-text-current:hover {
 
 
 .info-box {
-  background-color: var(--lightblue);
+  background-color: var(--lightest-blue);
   width: 50%;
   margin: 10px auto;
   padding: 10px 15px;

--- a/src/App.css
+++ b/src/App.css
@@ -18,7 +18,7 @@
 
   /* narrow */
   --hamburger: var(--blue);
-  --header-1024-item-border: var(--darkest);
+  --header-1024-item-border: var(--lightest);
   --header-1024-item-background: var(--blue);
   --header-1024-text: var(--light-blue-1);
   --header-1024-text-hover: var(--lightest);
@@ -204,7 +204,7 @@ h1, h2, h3 {
 #header_nav_container_1024 #header_nav {
   max-height: 0;
   overflow: hidden;
-  transition: 0.1s linear;
+  transition: max-height .3s ease;
 }
 
 /* WARNING: If the menu gets too much longer, this height must be increased */

--- a/src/App.css
+++ b/src/App.css
@@ -1,4 +1,5 @@
 :root {
+  --header-item-hover: #6C9FE1;
   --blue: #1A73E8;
   --lightblue: #F5F9FE;
 }
@@ -6,6 +7,21 @@
 #root {
   margin-top: 0;
   padding: 0;
+}
+
+div {
+  color: #6C757D;
+}
+
+section {
+  padding: 10px 30px 0 30px;
+}
+
+h1, h2, h3 {
+  color: black;
+  font-family: 'Quicksand', sans-serif;
+  font-size: 1.05rem;
+  font-weight: 700;
 }
 
 .topnav {
@@ -17,46 +33,22 @@
   text-align: right;
 }
 
+.separator {
+  border-bottom: 1px solid black;
+  margin: 0 auto;
+}
+
 #language-container {
   color: white;
   justify-content: space-between;
   line-height: 1.5em;
 }
 
+/* links? */
 .language-link {
   color: white;
   font-weight: 600;
   padding-right: 10px;
-}
-
-.App {
-  text-align: center;
-  font-family: "Roboto", sans-serif;
-  padding-right: 15%;
-  padding-left: 15%;
-  margin: 0 auto;
-}
-
-.separator {
-  border: 1px solid black;
-  margin: 0 auto;
-}
-
-div {
-  color: #6C757D;
-}
-
-h1, h2, h3 {
-  color: black;
-  font-family: 'Quicksand', sans-serif;
-}
-
-.header-link {
-  padding: 0px 5px 0px 5px;
-}
-
-.header-link-current {
-  color: var(--blue);
 }
 
 .normal .link {
@@ -69,7 +61,10 @@ h1, h2, h3 {
   color: var(--blue);
 }
 
-.link-no-decoration, .link-no-decoration:active, .link-no-decoration:link, .link-no-decoration:visited {
+.link-no-decoration,
+.link-no-decoration:active,
+.link-no-decoration:link,
+.link-no-decoration:visited {
   text-decoration: none;
 }
 
@@ -77,8 +72,78 @@ h1, h2, h3 {
   text-decoration: underline;
 }
 
-.call-to-action-link, .call-to-action-link:hover, .call-to-action-link:active, .call-to-action-link:link, .call-to-action-link:visited {
+.call-to-action-link,
+.call-to-action-link:hover,
+.call-to-action-link:active,
+.call-to-action-link:link,
+.call-to-action-link:visited {
   color: white;
+}
+
+/* App */
+.App {
+  text-align: center;
+  font-family: "Roboto", sans-serif;
+  margin: 0 auto;
+}
+/*
+#header_section {
+  padding-top: 10px;
+}*/
+
+#header {
+  justify-content: space-between;
+  align-items: center;
+}
+
+.header-part {
+  padding: 10px;
+}
+
+.header-part:first-child {
+  padding-left: 0;
+}
+
+.header-part:last-child {
+  padding: 0;
+}
+
+nav .header-link {
+  padding: 0 20px;
+}
+
+nav .header-link:first-child {
+  padding-left: 0;
+}
+
+nav .header-link:last-child {
+  padding-right: 0;
+}
+
+nav .header-link,
+nav .header-link:active,
+nav .header-link:link,
+nav .header-link:visited,
+nav .header-link:hover {
+  text-decoration: none;
+}
+
+.header-link-text {
+  margin: 0;
+  padding: 0px 5px 0px 5px;
+}
+
+.header-link-text:hover {
+  color: var(--header-item-hover);
+}
+
+.header-link-text:hover {
+  text-decoration: none;
+}
+
+nav .header-link-text-current,
+nav .header-link-text-current:hover {
+  color: var(--blue);
 }
 
 .row {

--- a/src/App.js
+++ b/src/App.js
@@ -53,31 +53,24 @@ function App() {
       setNavbarOpen(false);
     }
 
+    // For expansion animation to work, actual `nav` that
+    // does the collapsing and expanding must not be in a function.
+    // Looks like it might be something to do with the lifecycle.
+    const HeaderNavItem = props => {
+        return <li onClick={() => closeNav()} className={ props.className || '' }>
+            <a className={'header-link link-no-decoration'} href={ props.to }>
+                <span className={'header-link-text'}>{ props.contents }</span>
+            </a>
+        </li>
+    }
+
     const headerNavLinks = [
-        <nav id='header_nav' aria-hidden={navbarOpen ? 'false' : 'true'} className={navbarOpen ? 'expanded' : 'collapsed'}>
-            <ul>
-                <li onClick={() => closeNav()}>
-                    <a class='header-link link-no-decoration' href="https://madeuptocode.org/about/">
-                        <span className={'header-link-text'}>About</span>
-                    </a>
-                </li>
-                <li onClick={() => closeNav()}>
-                    <a class='header-link link-no-decoration' href="https://madeuptocode.org/faqs/">
-                        <span className={'header-link-text'}>FAQs</span>
-                    </a>
-                </li>
-                <li onClick={() => closeNav()}>
-                    <a class='header-link link-no-decoration' href="https://madeuptocode.org/find-your-inspector/">
-                        <span className={'header-link-text'}>Find Your Inspector</span>
-                    </a>
-                </li>
-                <li onClick={() => closeNav()} className={'header-item-current'}>
-                    <a className='header-link link-no-decoration' href={languageCode === "en" ? "/" : "/" + languageCode + "/"} >
-                        <span className={'header-link-text'} >Read the Code</span>
-                    </a>
-                </li>
-            </ul>
-        </nav>
+        <ul>
+            <HeaderNavItem to='https://madeuptocode.org/about/' contents='About'/>
+            <HeaderNavItem to='https://madeuptocode.org/faqs/' contents='FAQs'/>
+            <HeaderNavItem to='https://madeuptocode.org/find-your-inspector/' contents='Find Your Inspector'/>
+            <HeaderNavItem className='header-item-current' to={languageCode === "en" ? "/" : "/" + languageCode + "/"} contents='Read the Code'/>
+        </ul>
     ];
 
     const toggleNav = () => {
@@ -103,13 +96,16 @@ function App() {
                         </div>
 
                         <div id='header_nav_container_wide' className='header-part' aria-hidden={(windowWidth < 1024) ? "true" : "false"}>
-                            { headerNavLinks }
+                            <nav id='header_nav'>{ headerNavLinks }</nav>
                         </div>
+
                         <div id='header_nav_container_1024' className='header-part' aria-hidden={(windowWidth < 1024) ? "false" : "true"}>
                             <div className='toggle'>
-                                <button onClick={toggleNav} className='hamburger'>{navbarOpen ? "^" : "v"}</button>
+                                <div onClick={toggleNav} className='hamburger'>{navbarOpen ? "^" : "v"}</div>
                             </div>
-                            { headerNavLinks }
+                            <nav id='header_nav' aria-hidden={navbarOpen ? 'false' : 'true'} className={navbarOpen ? 'expanded' : 'collapsed'}>
+                                { headerNavLinks }
+                            </nav>
                         </div>
 
                     </div>

--- a/src/App.js
+++ b/src/App.js
@@ -39,10 +39,13 @@ function App() {
         setWindowWidth(window.innerWidth);
     });
 
-    const headerContents = [<UpToCodeLogo/>,
+    // Is this still used?
+    const headerContents = [
+        <UpToCodeLogo/>,
         <Link className='link-no-decoration' to={languageCode === "en" ? "/" : "/" + languageCode + "/"}>
             <h1>{translations[languageCode]["Massachusetts State Sanitary Code"]}</h1>
-        </Link>];
+        </Link>
+    ];
 
     return (
         <WindowWidthContext.Provider value={[windowWidth, setWindowWidth]}>
@@ -56,43 +59,48 @@ function App() {
                 </div>
             </div>
             <div className="App">
-                <div id={'header'}>
-                    <div style={{display: "flex", flexDirection:(windowWidth < 800)? "column" : "row"}}>
-                        <UpToCodeLogo/>
-                        <div style={{display: "flex", flexDirection:(windowWidth < 300)? "column" : "row", flex: 1, justifyContent: "space-between"}}>
-                            <div style={{display: "flex", flexDirection:(windowWidth < 300)? "column" : "row"}}>
-                                <a class='link-no-decoration' href="https://madeuptocode.org/about/">
-                                    <h3 className={'header-link'}>About</h3>
-                                </a>
-                                <a class='link-no-decoration' href="https://madeuptocode.org/faqs/">
-                                    <h3 className={'header-link'}>FAQs</h3>
-                                </a>
-                                <a class='link-no-decoration' href="https://madeuptocode.org/find-your-inspector/">
-                                    <h3 className={'header-link'}>Find Your Inspector</h3>
-                                </a>
-                                <a class='link-no-decoration' href={languageCode === "en" ? "/" : "/" + languageCode + "/"} >
-                                    <h3 className={'header-link header-link-current'} >Read the Code</h3>
-                                </a>
-                            </div>
-
+                <section id='header_section'>
+                    <div id='header' style={{display: "flex", flexDirection:(windowWidth < 800)? "column" : "row"}}>
+                        <div className='header-part logo'>
+                            <UpToCodeLogo/>
+                        </div>
+                        <div className='header-part header-links'>
+                            <nav className='nav' style={{display: "flex", flexDirection:(windowWidth < 300)? "column" : "row", flex: 1, justifyContent: "space-between"}}>
+                                <div style={{display: "flex", flexDirection:(windowWidth < 300)? "column" : "row"}}>
+                                    <a class='header-link link-no-decoration' href="https://madeuptocode.org/about/">
+                                        <h3 className={'header-link-text'}>About</h3>
+                                    </a>
+                                    <a class='header-link link-no-decoration' href="https://madeuptocode.org/faqs/">
+                                        <h3 className={'header-link-text'}>FAQs</h3>
+                                    </a>
+                                    <a class='header-link link-no-decoration' href="https://madeuptocode.org/find-your-inspector/">
+                                        <h3 className={'header-link-text'}>Find Your Inspector</h3>
+                                    </a>
+                                    <a class='header-link link-no-decoration' href={languageCode === "en" ? "/" : "/" + languageCode + "/"} >
+                                        <h3 className={'header-link-text header-link-text-current'} >Read the Code</h3>
+                                    </a>
+                                </div>
+                            </nav>
                         </div>
                     </div>
-                    <div className={'separator'}/>
-                </div>
-                <Routes>
-                    {Object.keys(translations).map((langCode) => {
-                        let pathLangCode = langCode + "/";
-                        if (langCode === "en") {
-                            pathLangCode = "";
-                        }
-                        console.log(pathLangCode)
-                        return (<Fragment key={"/" + pathLangCode}>
-                                <Route path={"/" + pathLangCode} element={<Home />} />
-                                <Route path={"/" + pathLangCode + "category/:categoryName"} element={<CategoryPage/>}/>
-                            </Fragment>
-                        );
-                    })}
-                </Routes>
+                </section>
+                <section><div className={'separator'}/></section>
+                <section>
+                    <Routes>
+                        {Object.keys(translations).map((langCode) => {
+                            let pathLangCode = langCode + "/";
+                            if (langCode === "en") {
+                                pathLangCode = "";
+                            }
+                            console.log(pathLangCode)
+                            return (<Fragment key={"/" + pathLangCode}>
+                                    <Route path={"/" + pathLangCode} element={<Home/>} />
+                                    <Route path={"/" + pathLangCode + "category/:categoryName"} element={<CategoryPage/>}/>
+                                </Fragment>
+                            );
+                        })}
+                    </Routes>
+                </section>
                 <div id={'footer'}>
                     <br/>
                     <div className={'separator'}/>

--- a/src/App.js
+++ b/src/App.js
@@ -17,6 +17,7 @@ function App() {
     const [checklist, setChecklist] = useState(housingChecklistJSON.data);
     const [languageCode, setLanguageCode] = useState("en");
     const [windowWidth, setWindowWidth] = useState(window.innerWidth);
+    const [navbarOpen, setNavbarOpen] = useState(false);
 
     let location = useLocation();
 
@@ -47,6 +48,42 @@ function App() {
         </Link>
     ];
 
+    
+    const closeNav = () => {
+      setNavbarOpen(false);
+    }
+
+    const headerNavLinks = [
+        <nav id='header_nav' aria-hidden={navbarOpen ? 'false' : 'true'} className={navbarOpen ? 'expanded' : 'collapsed'}>
+            <ul>
+                <li onClick={() => closeNav()}>
+                    <a class='header-link link-no-decoration' href="https://madeuptocode.org/about/">
+                        <span className={'header-link-text'}>About</span>
+                    </a>
+                </li>
+                <li onClick={() => closeNav()}>
+                    <a class='header-link link-no-decoration' href="https://madeuptocode.org/faqs/">
+                        <span className={'header-link-text'}>FAQs</span>
+                    </a>
+                </li>
+                <li onClick={() => closeNav()}>
+                    <a class='header-link link-no-decoration' href="https://madeuptocode.org/find-your-inspector/">
+                        <span className={'header-link-text'}>Find Your Inspector</span>
+                    </a>
+                </li>
+                <li onClick={() => closeNav()} className={'header-item-current'}>
+                    <a className='header-link link-no-decoration' href={languageCode === "en" ? "/" : "/" + languageCode + "/"} >
+                        <span className={'header-link-text'} >Read the Code</span>
+                    </a>
+                </li>
+            </ul>
+        </nav>
+    ];
+
+    const toggleNav = () => {
+      setNavbarOpen(prev => !prev);
+    }
+
     return (
         <WindowWidthContext.Provider value={[windowWidth, setWindowWidth]}>
         <LanguageCodeContext.Provider value={[languageCode, setLanguageCode]} >
@@ -60,31 +97,24 @@ function App() {
             </div>
             <div className="App">
                 <section id='header_section'>
-                    <div id='header' style={{display: "flex", flexDirection:(windowWidth < 800)? "column" : "row"}}>
-                        <div className='header-part logo'>
+                    <div id='header'>
+                        <div className='header-part logo-container'>
                             <UpToCodeLogo/>
                         </div>
-                        <div className='header-part header-links'>
-                            <nav className='nav' style={{display: "flex", flexDirection:(windowWidth < 300)? "column" : "row", flex: 1, justifyContent: "space-between"}}>
-                                <div style={{display: "flex", flexDirection:(windowWidth < 300)? "column" : "row"}}>
-                                    <a class='header-link link-no-decoration' href="https://madeuptocode.org/about/">
-                                        <h3 className={'header-link-text'}>About</h3>
-                                    </a>
-                                    <a class='header-link link-no-decoration' href="https://madeuptocode.org/faqs/">
-                                        <h3 className={'header-link-text'}>FAQs</h3>
-                                    </a>
-                                    <a class='header-link link-no-decoration' href="https://madeuptocode.org/find-your-inspector/">
-                                        <h3 className={'header-link-text'}>Find Your Inspector</h3>
-                                    </a>
-                                    <a class='header-link link-no-decoration' href={languageCode === "en" ? "/" : "/" + languageCode + "/"} >
-                                        <h3 className={'header-link-text header-link-text-current'} >Read the Code</h3>
-                                    </a>
-                                </div>
-                            </nav>
+
+                        <div id='header_nav_container_wide' className='header-part' aria-hidden={(windowWidth < 1024) ? "true" : "false"}>
+                            { headerNavLinks }
                         </div>
+                        <div id='header_nav_container_1024' className='header-part' aria-hidden={(windowWidth < 1024) ? "false" : "true"}>
+                            <div className='toggle'>
+                                <button onClick={toggleNav} className='hamburger'>{navbarOpen ? "^" : "v"}</button>
+                            </div>
+                            { headerNavLinks }
+                        </div>
+
                     </div>
                 </section>
-                <section><div className={'separator'}/></section>
+                <div className={'separator'}/>
                 <section>
                     <Routes>
                         {Object.keys(translations).map((langCode) => {

--- a/src/components/UpToCodeLogo.js
+++ b/src/components/UpToCodeLogo.js
@@ -1,6 +1,6 @@
 const UpToCodeLogo = props => {
 	return  <a className={'logo link'} href={"https://madeuptocode.org"}>
-		<img src={process.env.PUBLIC_URL + "/logoWithText.svg"} width={220} alt="Up to Code logo"/>
+		<img src={process.env.PUBLIC_URL + "/logoWithText.svg"} alt="Up to Code logo"/>
 
 	</a>
 }

--- a/src/components/UpToCodeLogo.js
+++ b/src/components/UpToCodeLogo.js
@@ -1,6 +1,6 @@
 const UpToCodeLogo = props => {
-	return  <a className={'link'} style={{paddingTop: "20px", paddingRight: "20px"}} href={"https://madeuptocode.org"}>
-		<img src={process.env.PUBLIC_URL + "/logoWithText.svg"} width={200}/>
+	return  <a className={'logo link'} href={"https://madeuptocode.org"}>
+		<img src={process.env.PUBLIC_URL + "/logoWithText.svg"} width={220} alt="Up to Code logo"/>
 
 	</a>
 }


### PR DESCRIPTION
Is missing the hamburger menu because I couldn't find an installed icon library. Wasn't sure what you wanted to go with. There's fontawesome and react icons that I know of. [React icons](https://react-icons.github.io/react-icons/) seems to come with a bunch of icon libraries, including fontawesome.

Before merging this, merge #4, top (language) nav styles. It may bring up conflicts.

[Works on Chrome from full width to Galaxy Fold 280px width.]

Implements the dropdown/hamburger menu with React and js. Wasn't sure how you wanted to abstract stuff there, so I kept it in the same file.

The dropdown menu doesn't match in color of the WordPress site because the WordPress site's is colored brown, which I think is going to be fixed.

Starts to use CSS variable naming conventions that I did some research on and seem to make sense for complex styling like this. Also unintentionally started some rearranging. I did want to do that, but in a separate PR.

Addresses #5 