### PR TITLE
Use `HashRouter` to allow react router to get local files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,14 +3,14 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
-import { BrowserRouter } from "react-router-dom";
+import { HashRouter } from "react-router-dom";
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-      <BrowserRouter>
+      <HashRouter>
           <App />
-      </BrowserRouter>
+      </HashRouter>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
Couldn't check whether it deploys properly to gh-pages too.

> The issue is that when you use GH Pages that it has a specific address, your gh name + github.io. When you use your routes like you see mine are set it assumes that it is 'caffiendkitten.github.io/blogs" and not "caffiendkitten.github.io/myportfolio/blogs". The same happens with each link.

Edit: That is, gh-pages expects the route to be "caffiendkitten.github.io/myportfolio/blogs" and the local environment expects it to be "caffiendkitten.github.io/blogs" and those don't mesh with each other. I'm not familiar enough with `HashRouter` to understand how it fixes that problem. It may make the url more complicated, which you may not want or may not be practical, I'm not sure. I'm reading that a "full url" is better for SEO, server rendering, etc.: https://reactrouter.com/en/6.4.5/routers/picking-a-router#web-projects.

Edit: If this isn't sufficient, these might be a good lead: https://create-react-app.dev/docs/deployment/#notes-on-client-side-routing, https://reactrouter.com/en/6.4.5/routers/picking-a-router (linked above). I'm not sure their solution of sending 404s to index.html will work for us because we're not getting a 404. Not sure how to deal with that.

Maybe related to #2